### PR TITLE
Synchronize search field options with current user input

### DIFF
--- a/src/components/algolia/AutoCompleteSearchField.js
+++ b/src/components/algolia/AutoCompleteSearchField.js
@@ -118,8 +118,12 @@ class SearchableSelect extends Component {
 
   async getOptions(inputValue) {
     await this.props.refine(inputValue);
-    return this.prepareLabels(this.props.hits);
+    return this.timeout(30).then(() => {return this.prepareLabels(this.props.hits)});
   }
+
+  async timeout(ms) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
 
   // Handle input change (any change)
   handleInputChange(inputValue) {


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Description
The problem is that I wait the refine method of Algolia, which request Algolia and receive the response; but this is not the only element that take time. 
The response of algolia is then parsed to the property "hits", it should be synchrone but it's async. 
