### PR TITLE
Fix: menu background filter in 'white'

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -141,6 +141,11 @@ export default createMuiTheme({
         },
       },
     },
+    MuiBackdrop: {
+      root: {
+        filter: 'brightness(0) invert(1)',
+      },
+    },
     //Cards
     MuiCard: {
       root: {


### PR DESCRIPTION
## Status
**READY**

## Description
white transparency to improve contrast for the dark menu
![image](https://user-images.githubusercontent.com/35458661/55321973-45301380-547b-11e9-9ea4-68ddaf12af8b.png)
